### PR TITLE
Potential fix for code scanning alert no. 32: Server-side request forgery

### DIFF
--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/fetchWithAuthToken.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/fetchWithAuthToken.ts
@@ -32,6 +32,14 @@ export async function fetchWithAuthToken(options: FetchWithKeyOptions) {
       throw new Error("No auth token found");
     }
 
+    // Disallow absolute URLs in endpoint to prevent overriding the allowed host.
+    if (
+      options.endpoint.startsWith("http://") ||
+      options.endpoint.startsWith("https://")
+    ) {
+      throw new Error("Absolute URLs are not allowed for endpoint");
+    }
+
     const endpointUrl = new URL(options.endpoint, ALLOWED_AI_HOST_URL);
 
     if (
@@ -43,6 +51,11 @@ export async function fetchWithAuthToken(options: FetchWithKeyOptions) {
 
     if (endpointUrl.hostname !== ALLOWED_AI_HOST_URL.hostname) {
       throw new Error("Endpoint host is not allowed");
+    }
+
+    // Ensure the resolved path does not escape the intended base via traversal.
+    if (endpointUrl.pathname.includes("/../") || endpointUrl.pathname.includes("/./")) {
+      throw new Error("Invalid endpoint path");
     }
 
     const response = await fetch(endpointUrl.toString(), {

--- a/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/session.ts
+++ b/apps/dashboard/src/app/(app)/team/[team_slug]/[project_slug]/(sidebar)/ai/api/session.ts
@@ -28,7 +28,7 @@ export async function createSession(params: {
   const res = await fetchWithAuthToken({
     project: params.project,
     body: body,
-    endpoint: `${NEXT_PUBLIC_THIRDWEB_AI_HOST}/session`,
+    endpoint: "/session",
     method: "POST",
   });
 
@@ -58,7 +58,7 @@ export async function updateSession(params: {
 
   const res = await fetchWithAuthToken({
     body: body,
-    endpoint: `${NEXT_PUBLIC_THIRDWEB_AI_HOST}/session/${params.sessionId}`,
+    endpoint: `/session/${encodeURIComponent(params.sessionId)}`,
     method: "PUT",
     project: params.project,
   });
@@ -76,7 +76,7 @@ export async function deleteSession(params: {
   sessionId: string;
 }) {
   const res = await fetchWithAuthToken({
-    endpoint: `${NEXT_PUBLIC_THIRDWEB_AI_HOST}/session/${params.sessionId}`,
+    endpoint: `/session/${encodeURIComponent(params.sessionId)}`,
     method: "DELETE",
     project: params.project,
   });
@@ -91,7 +91,7 @@ export async function deleteSession(params: {
 
 export async function getSessions(params: { project: Project }) {
   const res = await fetchWithAuthToken({
-    endpoint: `${NEXT_PUBLIC_THIRDWEB_AI_HOST}/session/list`,
+    endpoint: "/session/list",
     method: "GET",
     project: params.project,
   });
@@ -109,7 +109,7 @@ export async function getSessionById(params: {
   sessionId: string;
 }) {
   const res = await fetchWithAuthToken({
-    endpoint: `${NEXT_PUBLIC_THIRDWEB_AI_HOST}/session/${params.sessionId}`,
+    endpoint: `/session/${encodeURIComponent(params.sessionId)}`,
     method: "GET",
     project: params.project,
   });


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/embedded-smart-wallet/security/code-scanning/32](https://github.com/Dargon789/embedded-smart-wallet/security/code-scanning/32)

In general, to fix SSRF in this pattern you must ensure that untrusted data cannot arbitrarily control where the server sends requests. You already pin the protocol and hostname, which is good; the remaining gap is that path and query are unconstrained. The best fix while preserving existing behavior is to: (1) restrict `options.endpoint` so it cannot override the base host or protocol and cannot contain path traversal sequences; and (2) sanitize `sessionId` parameters so they are treated strictly as path-safe identifiers (e.g., allow only a conservative character set or URL-encode them).

Concretely:

- In `fetchWithAuthToken.ts`, instead of accepting any string for `options.endpoint`, treat it strictly as a *path* relative to the allowed host, and validate it:
  - Disallow absolute URLs (those starting with `http://` or `https://`), so callers cannot bypass the allow‑listed host.
  - Resolve the path against `ALLOWED_AI_HOST_URL` using `new URL(endpoint, ALLOWED_AI_HOST_URL)`.
  - Ensure the resulting URL still has the same origin (`protocol`, `hostname`, and `port`) as `ALLOWED_AI_HOST_URL`.
  - Ensure the resolved pathname does not contain suspicious traversal sequences such as `/../` or `/./`.
- In `session.ts`, stop concatenating `NEXT_PUBLIC_THIRDWEB_AI_HOST` into `endpoint` (that duplicates the host handling) and instead pass relative paths like `"/session"` or `"/session/" + encodedSessionId` into `fetchWithAuthToken`. To harden against path manipulation, URL‑encode `sessionId` when inserting it into the path via `encodeURIComponent(params.sessionId)`.

These changes keep all existing functional behavior (same endpoints, methods, headers) but address CodeQL’s concerns by ensuring: (a) callers can’t smuggle a different host/protocol via `endpoint`, and (b) path segments coming from user-controlled `sessionId` are sanitized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden AI API request handling to mitigate SSRF risks by constraining endpoints to the approved host and sanitizing session-related paths.

Bug Fixes:
- Prevent server-side request forgery by rejecting absolute URLs, enforcing same-origin checks, and blocking path traversal patterns in AI API endpoints.
- Sanitize session identifier path segments by URL-encoding them before constructing session-related API routes.

Enhancements:
- Standardize AI session API calls to use relative paths resolved against the configured allow-listed host.